### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/include/lsst/meas/extensions/psfex/Field.hh
+++ b/include/lsst/meas/extensions/psfex/Field.hh
@@ -33,8 +33,8 @@ class Set;
  * \brief Store all we know about for a visit to a field (maybe including multiple chips)
  */
 class Field {
-    friend void makeit(std::vector<boost::shared_ptr<Field> > &fields,
-                       std::vector<boost::shared_ptr<Set> > const& sets);
+    friend void makeit(std::vector<std::shared_ptr<Field> > &fields,
+                       std::vector<std::shared_ptr<Set> > const& sets);
 public:
     explicit Field(std::string const& ident="unknown" ///< Name of Field
          );
@@ -57,8 +57,8 @@ private:
    void _finalize(const bool force=false);
 };
 
-void makeit(std::vector<boost::shared_ptr<Field> > &fields,
-            std::vector<boost::shared_ptr<Set> > const& sets);
+void makeit(std::vector<std::shared_ptr<Field> > &fields,
+            std::vector<std::shared_ptr<Set> > const& sets);
 
 }}}}
 

--- a/include/lsst/meas/extensions/psfex/psf.hh
+++ b/include/lsst/meas/extensions/psfex/psf.hh
@@ -7,7 +7,7 @@
 #include <cstring>
 #include <string>
 #include <vector>
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 extern "C" {
 #include "context.h"
@@ -92,8 +92,8 @@ private:
     
 class Set {
     friend class Psf;
-    friend void makeit(std::vector<boost::shared_ptr<Field> > &fields,
-                       std::vector<boost::shared_ptr<Set> > const& sets);
+    friend void makeit(std::vector<std::shared_ptr<Field> > &fields,
+                       std::vector<std::shared_ptr<Set> > const& sets);
 public:
     Set(Context &c);
     ~Set();

--- a/python/lsst/meas/extensions/psfex/psfexLib.i
+++ b/python/lsst/meas/extensions/psfex/psfexLib.i
@@ -62,9 +62,9 @@ static double PSFEX_SAVE_INTERPFAC = INTERPFAC;
 %include "lsst/meas/extensions/psfex/prefs.hh"
 %include "lsst/meas/extensions/psfex/psf.hh"
 
-%template(vectorField) std::vector<boost::shared_ptr<lsst::meas::extensions::psfex::Field> >;
+%template(vectorField) std::vector<std::shared_ptr<lsst::meas::extensions::psfex::Field> >;
 %template(vectorPsf) std::vector<lsst::meas::extensions::psfex::Psf>;
-%template(vectorSet) std::vector<boost::shared_ptr<lsst::meas::extensions::psfex::Set> >;
+%template(vectorSet) std::vector<std::shared_ptr<lsst::meas::extensions::psfex::Set> >;
 
 %inline %{
    #undef BIG

--- a/src/PsfexPsf.cc
+++ b/src/PsfexPsf.cc
@@ -31,7 +31,7 @@
 #include <cassert>
 #include <numeric>
 
-#include "boost/make_shared.hpp"
+#include <memory>
 
 #include "lsst/base.h"
 #include "lsst/utils/ieee.h"

--- a/src/PsfexPsf.cc
+++ b/src/PsfexPsf.cc
@@ -90,7 +90,7 @@ PsfexPsf::~PsfexPsf()
 
 PTR(afw::detection::Psf)
 PsfexPsf::clone() const {
-    return boost::make_shared<PsfexPsf>(*this);
+    return std::make_shared<PsfexPsf>(*this);
 }
 
 PTR(afw::math::LinearCombinationKernel const)
@@ -158,11 +158,11 @@ PsfexPsf::getKernel(afw::geom::Point2D position) const
             }
         }
 
-        kernels.push_back(boost::make_shared<afw::math::FixedKernel>(kim));
+        kernels.push_back(std::make_shared<afw::math::FixedKernel>(kim));
         weights.push_back(_poly->basis[i]);
     }
 
-    _kernel = boost::make_shared<afw::math::LinearCombinationKernel>(kernels, weights);
+    _kernel = std::make_shared<afw::math::LinearCombinationKernel>(kernels, weights);
 
     return _kernel;
 }
@@ -242,7 +242,7 @@ PsfexPsf::_doComputeImage(afw::geom::Point2D const& position,
     //
     // And copy it into place
     //
-    PTR(afw::detection::Psf::Image) im = boost::make_shared<afw::detection::Psf::Image>(sampleW, sampleH);
+    PTR(afw::detection::Psf::Image) im = std::make_shared<afw::detection::Psf::Image>(sampleW, sampleH);
     // N.b. center[0] - dx == (int)center[x] until we reduced dx to (-0.5, 0.5].
     // The + 0.5 is to handle floating point imprecision in this calculation
     im->setXY0(static_cast<int>(center[0] - dx + 0.5) - sampleW/2,

--- a/src/psfexAdaptors.cc
+++ b/src/psfexAdaptors.cc
@@ -69,8 +69,8 @@ load_samples(char **filenames, int catindex, int ncat, int ext,
 namespace lsst { namespace meas { namespace extensions { namespace psfex {
 
 void
-makeit(std::vector<boost::shared_ptr<Field> > &fields_,
-       std::vector<boost::shared_ptr<Set> > const& sets
+makeit(std::vector<std::shared_ptr<Field> > &fields_,
+       std::vector<std::shared_ptr<Set> > const& sets
       )
 {
     if (sets.size() > MAXFILE) {
@@ -92,7 +92,7 @@ makeit(std::vector<boost::shared_ptr<Field> > &fields_,
         int const ncat;                 // Original number
         std::vector<char *> incat_name; // Original data
         size_t const setsSize;          // New size
-        ScribbleRaii(std::vector<boost::shared_ptr<Set> > const& sets) :
+        ScribbleRaii(std::vector<std::shared_ptr<Set> > const& sets) :
             ncat(prefs.ncat), incat_name(ncat), setsSize(sets.size())
         {
             for (int i = 0; i != prefs.ncat; ++i) {


### PR DESCRIPTION
Makes the following replacements:

- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
