### PR TITLE
DM-6815: config/default-lsst.psfex: change flux key

### DIFF
--- a/config/default-lsst.psfex
+++ b/config/default-lsst.psfex
@@ -11,8 +11,8 @@ PSF_ACCURACY    0.01            # Accuracy to expect from PSF "pixel" values
 #------------------------- Point source measurements -------------------------
  
 CENTER_KEYS     slot_Centroid_x,slot_Centroid_y # Catalogue parameters for source pre-centering
-PHOTFLUX_KEY    slot_ApFlux_flux    # Catalogue parameter for photometric norm.
-PHOTFLUXERR_KEY slot_ApFlux_fluxErr # Catalogue parameter for photometric error
+PHOTFLUX_KEY    base_CircularApertureFlux_9_0_flux      # Catalogue parameter for photometric norm
+PHOTFLUXERR_KEY base_CircularApertureFlux_9_0_fluxSigma # Catalogue parameter for photometric error
  
 #----------------------------- PSF variability -------------------------------
  


### PR DESCRIPTION
We want to use the battle tested HSC production run values as our defaults.
The current (and soon-to-be-obsolete) HSC 4.0.3 stack has:
PHOTFLUX_KEY    initial.flux.sinc
for which the sinc radius2 is set to 7 pixels.  The LSST stack does not use
a seperate sinc flux, preferring instead to measure circular aperture
fluxes where a maximum radius can be set for using the sinc algorithm to
compute them (falling back to the "naive" algorithm at larger radii), thus
the appropriate circular aperture flux can be used here (as long as it has
a radius smaller than maxSincRadius which is 12 pixels).  However, radius=7
is not included in the list of aperture radii.  The closest would be 6, but
we opt for the larger value of 9 pixels (as smaller radii could cut out too
much of the flux).

The aperture flux slot is currently set to base_CircularApertureFlux_12_0
