### PR TITLE
Add computeBBox method

### DIFF
--- a/include/lsst/meas/extensions/psfex/PsfexPsf.h
+++ b/include/lsst/meas/extensions/psfex/PsfexPsf.h
@@ -97,6 +97,20 @@ private:
         lsst::afw::image::Color const& color       ///< colour of object
     ) const;
 
+    /// Compute the bbox of the kernel image at the specified position/color
+    virtual lsst::afw::geom::Box2I doComputeBBox(
+        lsst::afw::geom::Point2D const & position,
+        lsst::afw::image::Color const & color
+    ) const;
+
+    /// Compute bbox of either image or kernel image, depending on provided center
+    /// Does not depend on color, which is left out of parameter list to permit reuse
+    /// by doComputeBBox, doCompute[Kernel]Image, and getKernel.
+    lsst::afw::geom::Box2I _doComputeBBox(
+        lsst::afw::geom::Point2D const & position, ///< position within the chip
+        lsst::afw::geom::Point2D const & center ///< center of output image. Use (0., 0.) for a kernel image
+    ) const;
+
     /// Name used in table persistence
     virtual std::string getPersistenceName() const;
     /// The python module name (for use in table persistence)

--- a/tests/testPsfexPsf.py
+++ b/tests/testPsfexPsf.py
@@ -273,6 +273,10 @@ class SpatialModelPsfTestCase(unittest.TestCase):
         # Test how well we can subtract the PSF model
         self.subtractStars(self.exposure, self.catalog, chi_lim=4.6)
 
+        # Test PsfexPsf.computeBBox
+        self.assertEqual(psf.computeBBox(), psf.computeKernelImage().getBBox())
+        self.assertEqual(psf.computeBBox(), psf.getKernel().getBBox())
+
 #-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
 
 


### PR DESCRIPTION
Some explanation of choices. 

PsfexPsf already has a confusing level of code duplication between getKernel(position) _doComputeImage(position, color, center).  It could probably be refactored to inherit from KernelPsf.
While extracting the bbox-computing portion into its own method isn't 100% clean, it doesn't introduce any more code duplication.  I left color out of the parameter list of the private worker function _doComputeBBox because the getKernel() method seems to intentionally side step typical way we pass around the default colors defined in afw.detection.Psf by not inheriting from KernelPsf and leaving color off its parameter list.