### PR TITLE
DM-9937: Add noexcept specifiers to applicable methods in afw

### DIFF
--- a/include/lsst/meas/extensions/psfex/PsfexPsf.h
+++ b/include/lsst/meas/extensions/psfex/PsfexPsf.h
@@ -66,7 +66,7 @@ public:
               lsst::afw::geom::Point2D(std::numeric_limits<double>::quiet_NaN())) const;
 
     /// Is this object persistable?
-    virtual bool isPersistable() const { return true; }
+    virtual bool isPersistable() const noexcept override { return true; }
     
     void write(lsst::afw::table::io::OutputArchiveHandle & handle) const;
 private:


### PR DESCRIPTION
lsst/afw#366 adds a `noexcept` specifier to `afw::table::io::Persistence::isPersistable`. This PR adds a `noexcept` specifier to all methods that override `Persistence::isPersistable`, as required by type safety.