### PR TITLE
DM-27384: Do not try to document now-removed utils module.

### DIFF
--- a/doc/lsst.meas.extensions.psfex/index.rst
+++ b/doc/lsst.meas.extensions.psfex/index.rst
@@ -39,7 +39,3 @@ Python API reference
 .. .. automodapi:: lsst.meas.extensions.psfex.psfexStarSelector
 ..   :no-main-docstr:
 ..   :no-inheritance-diagram:
-
-.. automodapi:: lsst.meas.extensions.psfex.utils
-   :no-main-docstr:
-   :no-inheritance-diagram:


### PR DESCRIPTION
This module was removed in 187e5c9.