### PR TITLE
DM-30015: Update Sphinx conf.py for documenteer 0.6

### DIFF
--- a/README
+++ b/README
@@ -1,5 +1,0 @@
-# meas_extensions_psfex
-
-An LSST Science Pipelines wrapper for the PSF Extractor from Astromatic:
-
-https://www.astromatic.net/software/psfex

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,8 @@
+#####################
+meas_extensions_psfex
+#####################
+
+``meas_extensions_psfex`` is a package in the `LSST Science Pipelines <https://pipelines.lsst.io>`_.
+
+The ``lsst.meas.extensions.psfex`` Python module profiles a wrapper around Astromatic's `psfex <https://www.astromatic.net/software/psfex>`_ PSF extractor.
+Documentation is available at https://pipelines.lsst.io/modules/lsst.meas.extensions.psfex/index.html.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,13 +1,13 @@
 """Sphinx configuration file for an LSST stack package.
-
-This configuration only affects single-package Sphinx documenation builds.
+This configuration only affects single-package Sphinx documentation builds.
+For more information, see:
+https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
-from documenteer.sphinxconfig.stackconf import build_package_configs
-import lsst.meas.extensions.psfex
+from documenteer.conf.pipelinespkg import *
 
 
-_g = globals()
-_g.update(build_package_configs(
-    project_name='meas_extensions_psfex',
-    version=lsst.meas.extensions.psfex.version.__version__))
+project = "meas_extensions_psfex"
+html_theme_options["logotext"] = project
+html_title = project
+html_short_title = project

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,12 @@
 max-line-length = 110
 max-doc-length = 79
 ignore = E133, E226, E228, N802, N803, N806, N812, N815, N816, W503, E266
-exclude = __init__.py
+exclude =
+    bin,
+    doc/conf.py,
+    **/*/__init__.py,
+    **/*/version.py,
+    tests/.tests,
     config/*.py
 
 [tool:pytest]


### PR DESCRIPTION
Updates based on the latest updates in the package template (https://github.com/lsst/templates/tree/master/project_templates/stack_package)

- Migrate README to ReStructuredText
- Update doc/conf.py for the documenteer 0.6 Sphinx configuration API
- Update flake8 exclusions in setup.cfg